### PR TITLE
add optional CMake build, allow MinGW GCC / Clang build

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: windows-2022
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
 
@@ -20,7 +20,7 @@ jobs:
         run: build.bat
 
       - name: Create release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           files: bin/studio-brightness.exe
         env:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.19)
+
+project(StudioBrightness LANGUAGES CXX)
+
+add_executable(studio-brightness WIN32 src/main.cpp src/hid.cpp studio-brightness.rc)
+
+target_include_directories(studio-brightness PRIVATE include)
+
+target_link_libraries(studio-brightness PRIVATE hid setupapi wbemuuid comctl32 User32 Shell32 Gdi32)
+
+target_compile_options(studio-brightness PRIVATE /W4)
+
+install(TARGETS studio-brightness)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,8 +14,12 @@ target_include_directories(studio-brightness PRIVATE include)
 
 target_link_libraries(studio-brightness PRIVATE hid setupapi wbemuuid comctl32 User32 Shell32 Gdi32)
 
-target_compile_options(studio-brightness PRIVATE "$<$<BOOL:${MSVC}>:/W4>")
-
 target_link_options(studio-brightness PRIVATE "$<$<BOOL:${MINGW}>:-municode>")
+
+if(MSVC)
+  target_compile_options(studio-brightness PRIVATE /W4)
+elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+  target_compile_options(studio-brightness PRIVATE -Wall -Wold-style-cast)
+endif()
 
 install(TARGETS studio-brightness)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ project(StudioBrightness LANGUAGES CXX)
 
 add_executable(studio-brightness WIN32 src/main.cpp src/hid.cpp studio-brightness.rc)
 
-target_compile_features(studio-brightness PRIVATE cxx_std_17)
+target_compile_features(studio-brightness PRIVATE cxx_std_20)
 
 target_include_directories(studio-brightness PRIVATE include)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,8 @@ project(StudioBrightness LANGUAGES CXX)
 
 add_executable(studio-brightness WIN32 src/main.cpp src/hid.cpp studio-brightness.rc)
 
+target_compile_features(studio-brightness PRIVATE cxx_std_17)
+
 target_include_directories(studio-brightness PRIVATE include)
 
 target_link_libraries(studio-brightness PRIVATE hid setupapi wbemuuid comctl32 User32 Shell32 Gdi32)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,9 @@
 cmake_minimum_required(VERSION 3.19)
 
+if(NOT DEFINED CMAKE_BUILD_TYPE AND NOT DEFINED ENV{CMAKE_BUILD_TYPE})
+  set(CMAKE_BUILD_TYPE Release CACHE STRING "Default build type")
+endif()
+
 project(StudioBrightness LANGUAGES CXX)
 
 add_executable(studio-brightness WIN32 src/main.cpp src/hid.cpp studio-brightness.rc)
@@ -8,6 +12,8 @@ target_include_directories(studio-brightness PRIVATE include)
 
 target_link_libraries(studio-brightness PRIVATE hid setupapi wbemuuid comctl32 User32 Shell32 Gdi32)
 
-target_compile_options(studio-brightness PRIVATE /W4)
+target_compile_options(studio-brightness PRIVATE "$<$<BOOL:${MSVC}>:/W4>")
+
+target_link_options(studio-brightness PRIVATE "$<$<BOOL:${MINGW}>:-municode>")
 
 install(TARGETS studio-brightness)

--- a/readme.md
+++ b/readme.md
@@ -9,18 +9,13 @@ To exit, left or right click on the icon in the taskbar notification area and cl
 
 ## Building
 
-Pick either one of `build.bat` or CMake to build:
+Pick either one of `build.bat` or CMake to build the executable "bin/studio-brightness.exe":
 
-Run `build.bat` in the Developer Command Prompt where cl.exe and rc.exe are in PATH.
+* run `build.bat` in the Developer Command Prompt where cl.exe and rc.exe are in PATH.
+* CMake works with compilers including Visual Studio, Intel oneAPI, MinGW GCC, Clang
 
-OR
+    ```sh
+    cmake -B bin
 
-CMake works with Visual Studio or Intel oneAPI compiler:
-
-```sh
-cmake -B bin
-
-cmake --build bin
-```
-
-The executable "bin/studio-brightness.exe" will be created.
+    cmake --build bin
+    ```

--- a/readme.md
+++ b/readme.md
@@ -9,4 +9,18 @@ To exit, left or right click on the icon in the taskbar notification area and cl
 
 ## Building
 
+Pick either one of `build.bat` or CMake to build:
+
 Run `build.bat` in the Developer Command Prompt where cl.exe and rc.exe are in PATH.
+
+OR
+
+CMake works with Visual Studio or Intel oneAPI compiler:
+
+```sh
+cmake -B bin
+
+cmake --build bin
+```
+
+The executable "bin/studio-brightness.exe" will be created.

--- a/src/hid.cpp
+++ b/src/hid.cpp
@@ -60,7 +60,7 @@ int hid_init () {
       strstr(propBuf, collectionStr))
       continue;
 
-    // printf("Device found: %s\n", propBuf);
+    // std::printf("Device found: %s\n", propBuf);
 
     deviceInterfaceData.cbSize = sizeof(SP_DEVICE_INTERFACE_DATA);
     SetupDiEnumDeviceInterfaces(hDevInfoSet, nullptr, &hidGuid, memberIndex, &deviceInterfaceData);

--- a/src/hid.cpp
+++ b/src/hid.cpp
@@ -4,9 +4,9 @@
 #include <wbemidl.h>
 #include <hidsdi.h>
 #include <setupapi.h>
-#include <stdio.h>
-#include <stdint.h>
-#include <string.h>
+#include <cstdio>
+#include <cstdint>
+#include <cstring>
 
 // Apple Studio Display
 static const char vidStr[] = "VID_05AC";
@@ -15,7 +15,7 @@ static const char interfaceStr[] = "MI_07";
 static const char collectionStr[] = "Col";
 
 static HANDLE hDeviceObject = INVALID_HANDLE_VALUE;
-static PHIDP_PREPARSED_DATA preparsedData = NULL;
+static PHIDP_PREPARSED_DATA preparsedData = nullptr;
 
 static struct {
   USHORT reportLength;
@@ -35,7 +35,7 @@ int hid_init () {
 
   HidD_GetHidGuid(&hidGuid);
 
-  HDEVINFO hDevInfoSet = SetupDiGetClassDevs(&hidGuid, NULL, 0, DIGCF_PRESENT | DIGCF_DEVICEINTERFACE);
+  HDEVINFO hDevInfoSet = SetupDiGetClassDevs(&hidGuid, nullptr, 0, DIGCF_PRESENT | DIGCF_DEVICEINTERFACE);
   if (hDevInfoSet == INVALID_HANDLE_VALUE) return -2;
 
   for (DWORD memberIndex = 0; ; memberIndex++) {
@@ -54,22 +54,22 @@ int hid_init () {
       return -4;
     }
 
-    if (strstr(propBuf, vidStr) == NULL ||
-      strstr(propBuf, pidStr) == NULL ||
-      strstr(propBuf, interfaceStr) == NULL ||
-      strstr(propBuf, collectionStr) != NULL)
+    if (!strstr(propBuf, vidStr) ||
+      !strstr(propBuf, pidStr) ||
+      !strstr(propBuf, interfaceStr) ||
+      strstr(propBuf, collectionStr))
       continue;
 
     // printf("Device found: %s\n", propBuf);
-    
+
     deviceInterfaceData.cbSize = sizeof(SP_DEVICE_INTERFACE_DATA);
-    SetupDiEnumDeviceInterfaces(hDevInfoSet, NULL, &hidGuid, memberIndex, &deviceInterfaceData);
+    SetupDiEnumDeviceInterfaces(hDevInfoSet, nullptr, &hidGuid, memberIndex, &deviceInterfaceData);
 
     memset(propBuf, 0, sizeof(propBuf));
     PSP_DEVICE_INTERFACE_DETAIL_DATA deviceDetailData = (PSP_DEVICE_INTERFACE_DETAIL_DATA)propBuf;
     deviceDetailData->cbSize = sizeof(SP_DEVICE_INTERFACE_DETAIL_DATA);
 
-    if (!SetupDiGetDeviceInterfaceDetail(hDevInfoSet, &deviceInterfaceData, deviceDetailData, sizeof(propBuf), &size, NULL)) {
+    if (!SetupDiGetDeviceInterfaceDetail(hDevInfoSet, &deviceInterfaceData, deviceDetailData, sizeof(propBuf), &size, nullptr)) {
       SetupDiDestroyDeviceInfoList(hDevInfoSet);
       return -5;
     }
@@ -107,7 +107,7 @@ int hid_init () {
     inputCaps.reportId = valueCaps[0].ReportID;
     inputCaps.usage = valueCaps[0].NotRange.Usage;
     inputCaps.usagePage = valueCaps[0].UsagePage;
-    
+
     memset(propBuf, 0, sizeof(propBuf));
     valueCapsLength = 2;
     HidP_GetValueCaps(HidP_Feature, valueCaps, &valueCapsLength, preparsedData);
@@ -155,9 +155,9 @@ int hid_setBrightness (ULONG val) {
 }
 
 void hid_deinit () {
-  if (preparsedData != NULL) {
+  if (preparsedData) {
     HidD_FreePreparsedData(preparsedData);
-    preparsedData = NULL;
+    preparsedData = nullptr;
   }
 
   if (hDeviceObject != INVALID_HANDLE_VALUE) {

--- a/src/hid.cpp
+++ b/src/hid.cpp
@@ -49,7 +49,7 @@ int hid_init () {
 
     // Get required size for device property
     memset(propBuf, 0, sizeof(propBuf));
-    if (!SetupDiGetDeviceRegistryProperty(hDevInfoSet, &deviceInfoData, SPDRP_HARDWAREID, &type, (PBYTE)propBuf, sizeof(propBuf), &size)) {
+    if (!SetupDiGetDeviceRegistryProperty(hDevInfoSet, &deviceInfoData, SPDRP_HARDWAREID, &type, reinterpret_cast<PBYTE>(propBuf), sizeof(propBuf), &size)) {
       SetupDiDestroyDeviceInfoList(hDevInfoSet);
       return -4;
     }
@@ -66,7 +66,7 @@ int hid_init () {
     SetupDiEnumDeviceInterfaces(hDevInfoSet, nullptr, &hidGuid, memberIndex, &deviceInterfaceData);
 
     memset(propBuf, 0, sizeof(propBuf));
-    PSP_DEVICE_INTERFACE_DETAIL_DATA deviceDetailData = (PSP_DEVICE_INTERFACE_DETAIL_DATA)propBuf;
+    PSP_DEVICE_INTERFACE_DETAIL_DATA deviceDetailData = reinterpret_cast<PSP_DEVICE_INTERFACE_DETAIL_DATA>(propBuf);
     deviceDetailData->cbSize = sizeof(SP_DEVICE_INTERFACE_DETAIL_DATA);
 
     if (!SetupDiGetDeviceInterfaceDetail(hDevInfoSet, &deviceInterfaceData, deviceDetailData, sizeof(propBuf), &size, nullptr)) {
@@ -85,7 +85,7 @@ int hid_init () {
     }
 
     memset(propBuf, 0, sizeof(propBuf));
-    PHIDP_CAPS caps = (PHIDP_CAPS)propBuf;
+    PHIDP_CAPS caps = reinterpret_cast<PHIDP_CAPS>(propBuf);
     if (HidP_GetCaps(preparsedData, caps) != HIDP_STATUS_SUCCESS) {
       hid_deinit();
       return -8;
@@ -95,7 +95,7 @@ int hid_init () {
     featureCaps.reportLength = caps->FeatureReportByteLength;
 
     memset(propBuf, 0, sizeof(propBuf));
-    PHIDP_VALUE_CAPS valueCaps = (PHIDP_VALUE_CAPS)propBuf;
+    PHIDP_VALUE_CAPS valueCaps = reinterpret_cast<PHIDP_VALUE_CAPS>(propBuf);
 
     USHORT valueCapsLength = 2;
     HidP_GetValueCaps(HidP_Input, valueCaps, &valueCapsLength, preparsedData);
@@ -132,7 +132,7 @@ int hid_getBrightness (ULONG *val) {
   dataBuf[0] = inputCaps.reportId;
   if (!HidD_GetInputReport(hDeviceObject, dataBuf, sizeof(dataBuf))) return -2;
 
-  NTSTATUS status = HidP_GetUsageValue(HidP_Input, inputCaps.usagePage, 0, inputCaps.usage, val, preparsedData, (PCHAR)dataBuf, inputCaps.reportLength);
+  NTSTATUS status = HidP_GetUsageValue(HidP_Input, inputCaps.usagePage, 0, inputCaps.usage, val, preparsedData, reinterpret_cast<PCHAR>(dataBuf), inputCaps.reportLength);
   if (status != HIDP_STATUS_SUCCESS) return -3;
 
   return 0;
@@ -146,7 +146,7 @@ int hid_setBrightness (ULONG val) {
   dataBuf[0] = featureCaps.reportId;
   if (!HidD_GetFeature(hDeviceObject, dataBuf, sizeof(dataBuf))) return -2;
 
-  NTSTATUS status = HidP_SetUsageValue(HidP_Feature, featureCaps.usagePage, 0, featureCaps.usage, val, preparsedData, (PCHAR)dataBuf, featureCaps.reportLength);
+  NTSTATUS status = HidP_SetUsageValue(HidP_Feature, featureCaps.usagePage, 0, featureCaps.usage, val, preparsedData, reinterpret_cast<PCHAR>(dataBuf), featureCaps.reportLength);
   if (status != HIDP_STATUS_SUCCESS) return -3;
 
   if (!HidD_SetFeature(hDeviceObject, dataBuf, featureCaps.reportLength)) return -4;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -18,9 +18,9 @@
 
 static HINSTANCE g_hInst = nullptr;
 
-static UINT const WMAPP_NOTIFYCALLBACK = WM_APP + 1;
+constexpr UINT WMAPP_NOTIFYCALLBACK = WM_APP + 1;
 
-static wchar_t const szWindowClass[] = L"NotificationIconTest";
+constexpr wchar_t szWindowClass[] = L"NotificationIconTest";
 
 // Use a guid to uniquely identify our icon "9D0B8B92-4E1C-488e-A1E1-2331AFCE2CB5"
 DEFINE_GUID(GUID_PrinterIcon, 0x9D0B8B92, 0x4E1C, 0x488e, 0xA1, 0xE1, 0x23, 0x31, 0xAF, 0xCE, 0x2C, 0xB5);
@@ -31,13 +31,13 @@ LRESULT CALLBACK    WndProc(HWND, UINT, WPARAM, LPARAM);
 BOOL                AddNotificationIcon(HWND hwnd);
 BOOL                DeleteNotificationIcon();
 
-#define BRIGHTNESS_STEP 5000
-#define BRIGHTNESS_MIN 400
-#define BRIGHTNESS_MAX 60000
-#define HOLD_KEY_1 VK_LSHIFT
-#define HOLD_KEY_2 VK_LWIN
-#define DOWN_KEY VK_LEFT
-#define UP_KEY VK_RIGHT
+constexpr ULONG BRIGHTNESS_STEP = 5000;
+constexpr ULONG BRIGHTNESS_MIN = 400;
+constexpr ULONG BRIGHTNESS_MAX = 60000;
+constexpr DWORD HOLD_KEY_1 = VK_LSHIFT;
+constexpr DWORD HOLD_KEY_2 = VK_LWIN;
+constexpr DWORD DOWN_KEY = VK_LEFT;
+constexpr DWORD UP_KEY = VK_RIGHT;
 
 static HHOOK hook = nullptr;
 static bool holdKey1Down = false;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -77,7 +77,7 @@ static void onStepUp () {
 LRESULT hookCallback(int nCode, WPARAM wParam, LPARAM lParam) {
   if (nCode < 0) return CallNextHookEx(hook, nCode, wParam, lParam);
 
-  KBDLLHOOKSTRUCT kbdStruct = *((KBDLLHOOKSTRUCT*)lParam);
+  KBDLLHOOKSTRUCT kbdStruct = *reinterpret_cast<KBDLLHOOKSTRUCT*>(lParam);
   if (wParam == WM_KEYDOWN) {
     if (kbdStruct.vkCode == HOLD_KEY_1) {
       holdKey1Down = true;
@@ -119,7 +119,7 @@ void RegisterWindowClass(PCWSTR pszClassName, PCWSTR pszMenuName, WNDPROC lpfnWn
     wcex.hInstance      = g_hInst;
     wcex.hIcon          = LoadIcon(g_hInst, MAKEINTRESOURCE(IDI_NOTIFICATIONICON));
     wcex.hCursor        = LoadCursor(nullptr, IDC_ARROW);
-    wcex.hbrBackground  = (HBRUSH)(COLOR_WINDOW+1);
+    wcex.hbrBackground  = reinterpret_cast<HBRUSH>(COLOR_WINDOW+1);
     wcex.lpszMenuName   = pszMenuName;
     wcex.lpszClassName  = pszClassName;
     RegisterClassExW(&wcex);
@@ -177,7 +177,7 @@ BOOL AddNotificationIcon(HWND hwnd)
     nid.uFlags = NIF_ICON | NIF_TIP | NIF_MESSAGE | NIF_SHOWTIP | NIF_GUID;
     nid.guidItem = GUID_PrinterIcon;
     nid.uCallbackMessage = WMAPP_NOTIFYCALLBACK;
-    nid.hIcon = (HICON)LoadImage(GetModuleHandle(nullptr), MAKEINTRESOURCE(IDI_MYICON), IMAGE_ICON, 0, 0, LR_DEFAULTSIZE | LR_SHARED);
+    nid.hIcon = static_cast<HICON>(LoadImage(GetModuleHandle(nullptr), MAKEINTRESOURCE(IDI_MYICON), IMAGE_ICON, 0, 0, LR_DEFAULTSIZE | LR_SHARED));
     LoadString(g_hInst, IDS_TOOLTIP, nid.szTip, ARRAYSIZE(nid.szTip));
     Shell_NotifyIcon(NIM_ADD, &nid);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -14,6 +14,7 @@
 #include <strsafe.h>
 #include "resource.h"
 #include "hid.h"
+#include <initguid.h>
 
 static HINSTANCE g_hInst = nullptr;
 
@@ -21,13 +22,8 @@ static UINT const WMAPP_NOTIFYCALLBACK = WM_APP + 1;
 
 static wchar_t const szWindowClass[] = L"NotificationIconTest";
 
-#ifdef __MINGW32__
-#include <initguid.h>
+// Use a guid to uniquely identify our icon "9D0B8B92-4E1C-488e-A1E1-2331AFCE2CB5"
 DEFINE_GUID(GUID_PrinterIcon, 0x9D0B8B92, 0x4E1C, 0x488e, 0xA1, 0xE1, 0x23, 0x31, 0xAF, 0xCE, 0x2C, 0xB5);
-#else
-// Use a guid to uniquely identify our icon
-class __declspec(uuid("9D0B8B92-4E1C-488e-A1E1-2331AFCE2CB5")) PrinterIcon;
-#endif
 
 // Forward declarations of functions included in this code module:
 void                RegisterWindowClass(PCWSTR pszClassName, PCWSTR pszMenuName, WNDPROC lpfnWndProc);
@@ -131,7 +127,7 @@ void RegisterWindowClass(PCWSTR pszClassName, PCWSTR pszMenuName, WNDPROC lpfnWn
     RegisterClassExW(&wcex);
 }
 
-int APIENTRY wWinMain(HINSTANCE hInstance, HINSTANCE, PWSTR /*lpCmdLine*/, int nCmdShow)
+int APIENTRY wWinMain(HINSTANCE hInstance, HINSTANCE, [[maybe_unused]] PWSTR lpCmdLine, [[maybe_unused]] int nCmdShow)
 {
     g_hInst = hInstance;
     RegisterWindowClass(szWindowClass, MAKEINTRESOURCEW(IDC_NOTIFICATIONICON), WndProc);
@@ -184,12 +180,7 @@ BOOL AddNotificationIcon(HWND hwnd)
     // add the icon, setting the icon, tooltip, and callback message.
     // the icon will be identified with the GUID
     nid.uFlags = NIF_ICON | NIF_TIP | NIF_MESSAGE | NIF_SHOWTIP | NIF_GUID;
-    nid.guidItem =
-#ifdef __MINGW32__
-        GUID_PrinterIcon;
-#else
-     __uuidof(PrinterIcon);
-#endif
+    nid.guidItem = GUID_PrinterIcon;
     nid.uCallbackMessage = WMAPP_NOTIFYCALLBACK;
     nid.hIcon = (HICON)LoadImage(GetModuleHandle(nullptr), MAKEINTRESOURCE(IDI_MYICON), IMAGE_ICON, 0, 0, LR_DEFAULTSIZE | LR_SHARED);
     LoadString(g_hInst, IDS_TOOLTIP, nid.szTip, ARRAYSIZE(nid.szTip));
@@ -204,12 +195,7 @@ BOOL DeleteNotificationIcon()
 {
     NOTIFYICONDATA nid = {sizeof(nid)};
     nid.uFlags = NIF_GUID;
-    nid.guidItem =
-#ifdef __MINGW32__
-        GUID_PrinterIcon;
-#else
-        __uuidof(PrinterIcon);
-#endif
+    nid.guidItem = GUID_PrinterIcon;
     return Shell_NotifyIcon(NIM_DELETE, &nid);
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,6 +15,8 @@
 #include "resource.h"
 #include "hid.h"
 #include <initguid.h>
+#include <format>
+#include <cstdlib>
 
 static HINSTANCE g_hInst = nullptr;
 
@@ -53,9 +55,7 @@ static void onStepDown () {
 
   int err = hid_setBrightness(currentBrightness);
   if (err < 0) {
-    char errStr[100];
-    snprintf(errStr, sizeof(errStr), "hid_setBrightness returned %d\n", err);
-    MessageBoxA(nullptr, errStr, "studio-brightness", MB_ICONINFORMATION);
+    MessageBoxA(nullptr, std::format("hid_setBrightness returned {}\n", err).data(), "studio-brightness", MB_ICONERROR);
     currentBrightness = 30000;
   }
 }
@@ -69,9 +69,7 @@ static void onStepUp () {
 
   int err = hid_setBrightness(currentBrightness);
   if (err < 0) {
-    char errStr[100];
-    snprintf(errStr, sizeof(errStr), "hid_setBrightness returned %d\n", err);
-    MessageBoxA(nullptr, errStr, "studio-brightness", MB_ICONINFORMATION);
+    MessageBoxA(nullptr, std::format("hid_setBrightness returned {}\n", err).data(), "studio-brightness", MB_ICONERROR);
     currentBrightness = 30000;
   }
 }
@@ -139,25 +137,22 @@ int APIENTRY wWinMain(HINSTANCE hInstance, HINSTANCE, [[maybe_unused]] PWSTR lpC
     HWND hwnd = CreateWindowW(szWindowClass, szTitle, WS_OVERLAPPEDWINDOW,
         CW_USEDEFAULT, 0, 250, 200, nullptr, nullptr, g_hInst, nullptr);
 
-    char errStr[100];
-
     int err = hid_init();
     if (err < 0) {
-      snprintf(errStr, sizeof(errStr), "hid_init returned %d\n", err);
-      MessageBoxA(nullptr, errStr, "studio-brightness", MB_ICONINFORMATION);
+      MessageBoxA(nullptr, std::format("hid_init returned {}", err).data(), "studio-brightness", MB_ICONERROR);
+      return EXIT_FAILURE;
     }
 
     err = hid_getBrightness(&currentBrightness);
     if (err < 0) {
-      snprintf(errStr, sizeof(errStr), "hid_getBrightness returned %d\n", err);
-      MessageBoxA(nullptr, errStr, "studio-brightness", MB_ICONINFORMATION);
+      MessageBoxA(nullptr, std::format("hid_getBrightness returned {}", err).data(), "studio-brightness", MB_ICONERROR);
       currentBrightness = 30000;
     }
 
     err = initKeyboardHook();
     if (err < 0) {
-      snprintf(errStr, sizeof(errStr), "initKeyboardHook returned %d\n", err);
-      MessageBoxA(nullptr, errStr, "studio-brightness", MB_ICONINFORMATION);
+      MessageBoxA(nullptr, std::format("initKeyboardhook returned {}", err).data(), "studio-brightness", MB_ICONERROR);
+      return EXIT_FAILURE;
     }
 
     if (hwnd)
@@ -170,7 +165,7 @@ int APIENTRY wWinMain(HINSTANCE hInstance, HINSTANCE, [[maybe_unused]] PWSTR lpC
             DispatchMessage(&msg);
         }
     }
-    return 0;
+    return EXIT_SUCCESS;
 }
 
 BOOL AddNotificationIcon(HWND hwnd)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,7 +4,7 @@
 // THE IMPLIED WARRANTIES OF MERCHANTABILITY AND/OR FITNESS FOR A
 // PARTICULAR PURPOSE.
 // Copyright (c) Microsoft Corporation. All rights reserved
-// 
+//
 // This derivative is sublicensed as Mozilla Public License Version 2.0
 
 #define WIN32_LEAN_AND_MEAN
@@ -21,8 +21,13 @@ static UINT const WMAPP_NOTIFYCALLBACK = WM_APP + 1;
 
 static wchar_t const szWindowClass[] = L"NotificationIconTest";
 
+#ifdef __MINGW32__
+#include <initguid.h>
+DEFINE_GUID(GUID_PrinterIcon, 0x9D0B8B92, 0x4E1C, 0x488e, 0xA1, 0xE1, 0x23, 0x31, 0xAF, 0xCE, 0x2C, 0xB5);
+#else
 // Use a guid to uniquely identify our icon
 class __declspec(uuid("9D0B8B92-4E1C-488e-A1E1-2331AFCE2CB5")) PrinterIcon;
+#endif
 
 // Forward declarations of functions included in this code module:
 void                RegisterWindowClass(PCWSTR pszClassName, PCWSTR pszMenuName, WNDPROC lpfnWndProc);
@@ -54,7 +59,7 @@ static void onStepDown () {
   if (err < 0) {
     char errStr[100];
     snprintf(errStr, sizeof(errStr), "hid_setBrightness returned %d\n", err);
-    MessageBox(NULL, errStr, "studio-brightness", MB_ICONINFORMATION);
+    MessageBoxA(NULL, errStr, "studio-brightness", MB_ICONINFORMATION);
     currentBrightness = 30000;
   }
 }
@@ -70,7 +75,7 @@ static void onStepUp () {
   if (err < 0) {
     char errStr[100];
     snprintf(errStr, sizeof(errStr), "hid_setBrightness returned %d\n", err);
-    MessageBox(NULL, errStr, "studio-brightness", MB_ICONINFORMATION);
+    MessageBoxA(NULL, errStr, "studio-brightness", MB_ICONINFORMATION);
     currentBrightness = 30000;
   }
 }
@@ -144,20 +149,20 @@ int APIENTRY wWinMain(HINSTANCE hInstance, HINSTANCE, PWSTR /*lpCmdLine*/, int n
     int err = hid_init();
     if (err < 0) {
       snprintf(errStr, sizeof(errStr), "hid_init returned %d\n", err);
-      MessageBox(NULL, errStr, "studio-brightness", MB_ICONINFORMATION);
+      MessageBoxA(NULL, errStr, "studio-brightness", MB_ICONINFORMATION);
     }
 
     err = hid_getBrightness(&currentBrightness);
     if (err < 0) {
       snprintf(errStr, sizeof(errStr), "hid_getBrightness returned %d\n", err);
-      MessageBox(NULL, errStr, "studio-brightness", MB_ICONINFORMATION);
+      MessageBoxA(NULL, errStr, "studio-brightness", MB_ICONINFORMATION);
       currentBrightness = 30000;
     }
 
     err = initKeyboardHook();
     if (err < 0) {
       snprintf(errStr, sizeof(errStr), "initKeyboardHook returned %d\n", err);
-      MessageBox(NULL, errStr, "studio-brightness", MB_ICONINFORMATION);
+      MessageBoxA(NULL, errStr, "studio-brightness", MB_ICONINFORMATION);
     }
 
     if (hwnd)
@@ -180,7 +185,12 @@ BOOL AddNotificationIcon(HWND hwnd)
     // add the icon, setting the icon, tooltip, and callback message.
     // the icon will be identified with the GUID
     nid.uFlags = NIF_ICON | NIF_TIP | NIF_MESSAGE | NIF_SHOWTIP | NIF_GUID;
-    nid.guidItem = __uuidof(PrinterIcon);
+    nid.guidItem =
+#ifdef __MINGW32__
+        GUID_PrinterIcon;
+#else
+     __uuidof(PrinterIcon);
+#endif
     nid.uCallbackMessage = WMAPP_NOTIFYCALLBACK;
     nid.hIcon = (HICON)LoadImage(GetModuleHandle(NULL), MAKEINTRESOURCE(IDI_MYICON), IMAGE_ICON, 0, 0, LR_DEFAULTSIZE | LR_SHARED);
     LoadString(g_hInst, IDS_TOOLTIP, nid.szTip, ARRAYSIZE(nid.szTip));
@@ -195,7 +205,12 @@ BOOL DeleteNotificationIcon()
 {
     NOTIFYICONDATA nid = {sizeof(nid)};
     nid.uFlags = NIF_GUID;
-    nid.guidItem = __uuidof(PrinterIcon);
+    nid.guidItem =
+#ifdef __MINGW32__
+        GUID_PrinterIcon;
+#else
+        __uuidof(PrinterIcon);
+#endif
     return Shell_NotifyIcon(NIM_DELETE, &nid);
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,7 +15,7 @@
 #include "resource.h"
 #include "hid.h"
 
-static HINSTANCE g_hInst = NULL;
+static HINSTANCE g_hInst = nullptr;
 
 static UINT const WMAPP_NOTIFYCALLBACK = WM_APP + 1;
 
@@ -43,7 +43,7 @@ BOOL                DeleteNotificationIcon();
 #define DOWN_KEY VK_LEFT
 #define UP_KEY VK_RIGHT
 
-static HHOOK hook = NULL;
+static HHOOK hook = nullptr;
 static bool holdKey1Down = false;
 static bool holdKey2Down = false;
 static ULONG currentBrightness = 30000;
@@ -59,7 +59,7 @@ static void onStepDown () {
   if (err < 0) {
     char errStr[100];
     snprintf(errStr, sizeof(errStr), "hid_setBrightness returned %d\n", err);
-    MessageBoxA(NULL, errStr, "studio-brightness", MB_ICONINFORMATION);
+    MessageBoxA(nullptr, errStr, "studio-brightness", MB_ICONINFORMATION);
     currentBrightness = 30000;
   }
 }
@@ -75,7 +75,7 @@ static void onStepUp () {
   if (err < 0) {
     char errStr[100];
     snprintf(errStr, sizeof(errStr), "hid_setBrightness returned %d\n", err);
-    MessageBoxA(NULL, errStr, "studio-brightness", MB_ICONINFORMATION);
+    MessageBoxA(nullptr, errStr, "studio-brightness", MB_ICONINFORMATION);
     currentBrightness = 30000;
   }
 }
@@ -106,15 +106,14 @@ LRESULT hookCallback(int nCode, WPARAM wParam, LPARAM lParam) {
 }
 
 int initKeyboardHook () {
-  hook = SetWindowsHookExW(WH_KEYBOARD_LL, hookCallback, NULL, 0);
-  if (hook == NULL) return -1;
-  return 0;
+  hook = SetWindowsHookExW(WH_KEYBOARD_LL, hookCallback, nullptr, 0);
+  return (hook) ? 0 : -1;
 }
 
 void deinitKeyboardHook () {
-  if (hook != NULL) {
+  if (hook) {
     UnhookWindowsHookEx(hook);
-    hook = NULL;
+    hook = nullptr;
   }
 }
 
@@ -125,7 +124,7 @@ void RegisterWindowClass(PCWSTR pszClassName, PCWSTR pszMenuName, WNDPROC lpfnWn
     wcex.lpfnWndProc    = lpfnWndProc;
     wcex.hInstance      = g_hInst;
     wcex.hIcon          = LoadIcon(g_hInst, MAKEINTRESOURCE(IDI_NOTIFICATIONICON));
-    wcex.hCursor        = LoadCursor(NULL, IDC_ARROW);
+    wcex.hCursor        = LoadCursor(nullptr, IDC_ARROW);
     wcex.hbrBackground  = (HBRUSH)(COLOR_WINDOW+1);
     wcex.lpszMenuName   = pszMenuName;
     wcex.lpszClassName  = pszClassName;
@@ -142,34 +141,34 @@ int APIENTRY wWinMain(HINSTANCE hInstance, HINSTANCE, PWSTR /*lpCmdLine*/, int n
     WCHAR szTitle[100];
     LoadStringW(hInstance, IDS_APP_TITLE, szTitle, ARRAYSIZE(szTitle));
     HWND hwnd = CreateWindowW(szWindowClass, szTitle, WS_OVERLAPPEDWINDOW,
-        CW_USEDEFAULT, 0, 250, 200, NULL, NULL, g_hInst, NULL);
+        CW_USEDEFAULT, 0, 250, 200, nullptr, nullptr, g_hInst, nullptr);
 
     char errStr[100];
 
     int err = hid_init();
     if (err < 0) {
       snprintf(errStr, sizeof(errStr), "hid_init returned %d\n", err);
-      MessageBoxA(NULL, errStr, "studio-brightness", MB_ICONINFORMATION);
+      MessageBoxA(nullptr, errStr, "studio-brightness", MB_ICONINFORMATION);
     }
 
     err = hid_getBrightness(&currentBrightness);
     if (err < 0) {
       snprintf(errStr, sizeof(errStr), "hid_getBrightness returned %d\n", err);
-      MessageBoxA(NULL, errStr, "studio-brightness", MB_ICONINFORMATION);
+      MessageBoxA(nullptr, errStr, "studio-brightness", MB_ICONINFORMATION);
       currentBrightness = 30000;
     }
 
     err = initKeyboardHook();
     if (err < 0) {
       snprintf(errStr, sizeof(errStr), "initKeyboardHook returned %d\n", err);
-      MessageBoxA(NULL, errStr, "studio-brightness", MB_ICONINFORMATION);
+      MessageBoxA(nullptr, errStr, "studio-brightness", MB_ICONINFORMATION);
     }
 
     if (hwnd)
     {
         // Main message loop:
         MSG msg;
-        while (GetMessage(&msg, NULL, 0, 0))
+        while (GetMessage(&msg, nullptr, 0, 0))
         {
             TranslateMessage(&msg);
             DispatchMessage(&msg);
@@ -192,7 +191,7 @@ BOOL AddNotificationIcon(HWND hwnd)
      __uuidof(PrinterIcon);
 #endif
     nid.uCallbackMessage = WMAPP_NOTIFYCALLBACK;
-    nid.hIcon = (HICON)LoadImage(GetModuleHandle(NULL), MAKEINTRESOURCE(IDI_MYICON), IMAGE_ICON, 0, 0, LR_DEFAULTSIZE | LR_SHARED);
+    nid.hIcon = (HICON)LoadImage(GetModuleHandle(nullptr), MAKEINTRESOURCE(IDI_MYICON), IMAGE_ICON, 0, 0, LR_DEFAULTSIZE | LR_SHARED);
     LoadString(g_hInst, IDS_TOOLTIP, nid.szTip, ARRAYSIZE(nid.szTip));
     Shell_NotifyIcon(NIM_ADD, &nid);
 
@@ -262,7 +261,7 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam)
 
               SetForegroundWindow(hwnd);
 
-              int cmd = TrackPopupMenu(hmenu, TPM_LEFTALIGN | TPM_LEFTBUTTON | TPM_BOTTOMALIGN | TPM_RETURNCMD, pt.x, pt.y, 0, hwnd, NULL);
+              int cmd = TrackPopupMenu(hmenu, TPM_LEFTALIGN | TPM_LEFTBUTTON | TPM_BOTTOMALIGN | TPM_RETURNCMD, pt.x, pt.y, 0, hwnd, nullptr);
               if (cmd != 0) DestroyWindow(hwnd);
           }
           break;


### PR DESCRIPTION
This makes the code approach more compiler-agnostic. It works on MSVC, oneAPI, GCC, Clang, ...

* Instead of using __uuidof, use DEFINE_GUID
* use constexpr instead of #define for explictness

* avoid using explict buffers with std::format
* abort program if critical error detected to avoid invisible hung program.
