### PR TITLE
Distinct internal code for monitor not detected

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
         run: cmake -B build -A ${{ matrix.arch }}
 
       - name: Build ${{ matrix.arch }}
-        run: cmake --build build --config RelWithDebInfo
+        run: cmake --build build --config Release
 
       - name: Upload ${{ matrix.arch }} executable
         uses: actions/upload-artifact@v4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,8 @@ add_executable(studio-brightness WIN32 src/main.cpp src/hid.cpp studio-brightnes
 
 target_compile_features(studio-brightness PRIVATE cxx_std_20)
 
+target_compile_definitions(studio-brightness PRIVATE $<$<CONFIG:Debug,RelWithDebInfo>:DEBUG_MESSAGES=1>)
+
 target_include_directories(studio-brightness PRIVATE include)
 
 target_link_libraries(studio-brightness PRIVATE hid setupapi wbemuuid comctl32 User32 Shell32 Gdi32)

--- a/build.bat
+++ b/build.bat
@@ -1,7 +1,11 @@
 md bin
 md obj
+
 set CXXFLAGS=-MD -O2 -W4 -Iinclude /std:c++20
-cl %CXXFLAGS% -c -Foobj/main.obj src/main.cpp
-cl %CXXFLAGS% -c -Foobj/hid.obj src/hid.cpp
+set CXXDEFS=/DDEBUG_MESSAGES=0
+@REM /DDEBUG_MESSAGES=1 to enable popup windows on error
+
+cl %CXXFLAGS% %CXXDEFS% -c -Foobj/main.obj src/main.cpp
+cl %CXXFLAGS% %CXXDEFS% -c -Foobj/hid.obj src/hid.cpp
 rc -Iinclude -foobj/studio-brightness.res studio-brightness.rc
 cl -MD -Fe./bin/studio-brightness.exe obj/main.obj obj/hid.obj obj/studio-brightness.res -link hid.lib setupapi.lib wbemuuid.lib comctl32.lib User32.lib Shell32.lib Gdi32.lib

--- a/readme.md
+++ b/readme.md
@@ -11,11 +11,27 @@ To exit, left or right click on the icon in the taskbar notification area and cl
 
 Pick either one of `build.bat` or CMake to build the executable "bin/studio-brightness.exe":
 
-* run `build.bat` in the Developer Command Prompt where cl.exe and rc.exe are in PATH.
-* CMake works with compilers including Visual Studio, Intel oneAPI, MinGW GCC, Clang
+Run `build.bat` in the Developer Command Prompt where cl.exe and rc.exe are in PATH.
 
-    ```sh
-    cmake -B bin
+Alternatively, CMake works with compilers including Visual Studio, Intel oneAPI, MinGW GCC, Clang, and more.
+The popup windows that appear on errors are disabled in Release builds.
+To enable them, set CMAKE_BUILD_TYPE=Debug in the CMake command line or in the CMake GUI.
 
-    cmake --build bin
-    ```
+Release build:
+
+```sh
+cmake -B bin
+
+cmake --build bin --config Release
+```
+
+To build in Debug mode, enabling popup windows on error, use the following commands:
+
+```sh
+cmake -B bin
+
+cmake --build bin --config Debug
+```
+
+Because the main entry point is wWinMain, the return code is always 0.
+If studio-brightness fails to start or run correctly, try building in CMake Debug build type to see the error message in a popup window.

--- a/readme.md
+++ b/readme.md
@@ -15,7 +15,7 @@ Run `build.bat` in the Developer Command Prompt where cl.exe and rc.exe are in P
 
 Alternatively, CMake works with compilers including Visual Studio, Intel oneAPI, MinGW GCC, Clang, and more.
 The popup windows that appear on errors are disabled in Release builds.
-To enable them, set CMAKE_BUILD_TYPE=Debug in the CMake command line or in the CMake GUI.
+To enable them, build in Debug mode.
 
 Release build:
 
@@ -25,7 +25,7 @@ cmake -B bin
 cmake --build bin --config Release
 ```
 
-To build in Debug mode, enabling popup windows on error, use the following commands:
+Debug build, enabling popup windows on error:
 
 ```sh
 cmake -B bin

--- a/src/hid.cpp
+++ b/src/hid.cpp
@@ -43,7 +43,9 @@ int hid_init () {
 
     // Get SP_DEVINFO_DATA for this member.
     if (!SetupDiEnumDeviceInfo(hDevInfoSet, memberIndex, &deviceInfoData)) {
+      DWORD err = GetLastError();
       SetupDiDestroyDeviceInfoList(hDevInfoSet);
+      if (err == ERROR_NO_MORE_ITEMS) break;
       return -3;
     }
 
@@ -122,6 +124,7 @@ int hid_init () {
 
     return 0;
   }
+  return -11; // Device not found
 }
 
 int hid_getBrightness (ULONG *val) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -241,7 +241,7 @@ LRESULT CALLBACK WndProc (HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam)
 
     case WM_MEASUREITEM:
     {
-      LPMEASUREITEMSTRUCT pmis = (LPMEASUREITEMSTRUCT)lParam;
+      LPMEASUREITEMSTRUCT pmis = reinterpret_cast<LPMEASUREITEMSTRUCT>(lParam);
       pmis->itemWidth = 250; // Specify width
       pmis->itemHeight = 25; // Specify height
       return TRUE;
@@ -249,7 +249,7 @@ LRESULT CALLBACK WndProc (HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam)
 
     case WM_DRAWITEM:
     {
-      LPDRAWITEMSTRUCT pdis = (LPDRAWITEMSTRUCT)lParam;
+      LPDRAWITEMSTRUCT pdis = reinterpret_cast<LPDRAWITEMSTRUCT>(lParam);
       HDC hdc = pdis->hDC;
       RECT rect = pdis->rcItem;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -117,7 +117,8 @@ void deinitKeyboardHook () {
 }
 
 void RegisterWindowClass (PCWSTR pszClassName, PCWSTR pszMenuName, WNDPROC lpfnWndProc) {
-  WNDCLASSEXW wcex = {sizeof(wcex)};
+  WNDCLASSEXW wcex = {};
+  wcex.cbSize        = sizeof(WNDCLASSEXW);
   wcex.style          = CS_HREDRAW | CS_VREDRAW;
   wcex.lpfnWndProc    = lpfnWndProc;
   wcex.hInstance      = g_hInst;
@@ -185,7 +186,8 @@ int APIENTRY wWinMain (HINSTANCE hInstance, HINSTANCE, [[maybe_unused]] PWSTR lp
 }
 
 BOOL AddNotificationIcon (HWND hwnd) {
-  NOTIFYICONDATA nid = {sizeof(nid)};
+  NOTIFYICONDATA nid = {};
+  nid.cbSize = sizeof(NOTIFYICONDATA);
   nid.hWnd = hwnd;
   // add the icon, setting the icon, tooltip, and callback message.
   // the icon will be identified with the GUID
@@ -203,10 +205,11 @@ BOOL AddNotificationIcon (HWND hwnd) {
 
 BOOL DeleteNotificationIcon ()
 {
-    NOTIFYICONDATA nid = {sizeof(nid)};
-    nid.uFlags = NIF_GUID;
-    nid.guidItem = GUID_PrinterIcon;
-    return Shell_NotifyIcon(NIM_DELETE, &nid);
+  NOTIFYICONDATA nid = {};
+  nid.cbSize = sizeof(nid);
+  nid.uFlags = NIF_GUID;
+  nid.guidItem = GUID_PrinterIcon;
+  return Shell_NotifyIcon(NIM_DELETE, &nid);
 }
 
 LRESULT CALLBACK WndProc (HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -18,7 +18,9 @@
 #include <format>
 #include <cstdlib>
 
+#ifndef DEBUG_MESSAGES
 #define DEBUG_MESSAGES 0
+#endif
 
 static HINSTANCE g_hInst = nullptr;
 
@@ -164,7 +166,7 @@ int APIENTRY wWinMain (HINSTANCE hInstance, HINSTANCE, [[maybe_unused]] PWSTR lp
   err = initKeyboardHook();
   if (err < 0) {
     #if DEBUG_MESSAGES
-    MessageBoxA(nullptr, std::format("initKeyboardhook returned {}", err).data(), "studio-brightness", MB_ICONERROR);
+    MessageBoxA(nullptr, std::format("initKeyboardHook returned {}", err).data(), "studio-brightness", MB_ICONERROR);
     #endif
     return EXIT_FAILURE;
   }
@@ -176,6 +178,8 @@ int APIENTRY wWinMain (HINSTANCE hInstance, HINSTANCE, [[maybe_unused]] PWSTR lp
       TranslateMessage(&msg);
       DispatchMessage(&msg);
     }
+  } else {
+    return EXIT_FAILURE;
   }
   return EXIT_SUCCESS;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -284,7 +284,7 @@ LRESULT CALLBACK WndProc (HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam)
 
           HMENU hmenu = CreatePopupMenu();
           InsertMenuW(hmenu, 0, MF_BYPOSITION | MF_OWNERDRAW, 100, L"Exit");
-          InsertMenuW(hmenu, 0, MF_BYPOSITION | MF_SEPARATOR, 0, NULL);
+          InsertMenuW(hmenu, 0, MF_BYPOSITION | MF_SEPARATOR, 0, nullptr);
           InsertMenuW(hmenu, 0, MF_BYPOSITION | MF_OWNERDRAW, 102, L"Decrease Brightness");
           InsertMenuW(hmenu, 0, MF_BYPOSITION | MF_OWNERDRAW, 101, L"Increase Brightness");
 


### PR DESCRIPTION
This adds @sfjohnson requested feature to have the program wait for a monitor to successfully be detected, without blocking the tray icon menu. This is a simple implementation. One could use callback with TimerProc and handle reconnection attempts.

This either connects immediately, or waits up to 3 minutes to connect.
If the connection is lost after connecting, the program needs to be restarted. 
The latter is how the program worked before too.

If you don't like this approach, just discard the final commit using setTimer, and a separate PR could figure out rearchitecting the main loop to enable reconnection attempts.

## background

Commit a404b0a46ecdc2d97fa539b593859e364b542280 disabled error popup windows by default. 
This is nice and with good cause (#8), but a side effect is that if a monitor is not found at all, the application silently exits.

This PR allows a build-time switch to enable popup windows to aid troubleshooting.
By default, the popups remain disabled as before.

The first five commits are all independent, but the final commit depends on them.

* The first two and fifth commits are code style/lint consistency.
* a8739e236d5cba448fc503ddf46ca89b124300fd allows build-time switch of Debug popup windows from CMake or build.bat
* e06ddc4a905530ad994c32207c1a2fb2c5f6d1a1 passes a unique internal return code if no monitors are found.