### PR TITLE
ci: build and upload ARM64 and x64 exe's

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,12 +18,23 @@ jobs:
 
   build-cmake:
     runs-on: windows-latest
+
+    strategy:
+      matrix:
+        arch: [ARM64, x64]
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Configure
-        run: cmake -B build
+      - name: Configure ${{ matrix.arch }}
+        run: cmake -B build -A ${{ matrix.arch }}
 
-      - name: Build
-        run: cmake --build build
+      - name: Build ${{ matrix.arch }}
+        run: cmake --build build --config RelWithDebInfo
+
+      - name: Upload ${{ matrix.arch }} executable
+        uses: actions/upload-artifact@v4
+        with:
+          name: studio-brightness-${{ matrix.arch }}.exe
+          path: build/RelWithDebInfo/studio-brightness.exe


### PR DESCRIPTION
These include the debug popup Windows to help users/devs test various systems.

Makes it easier for folks to tryout the latest development code.